### PR TITLE
Patch to work with freedesktop 18.08

### DIFF
--- a/com.viber.Viber.json
+++ b/com.viber.Viber.json
@@ -1,9 +1,9 @@
 {
   "app-id": "com.viber.Viber",
   "base": "io.atom.electron.BaseApp",
-  "base-version": "stable",
+  "base-version": "18.08",
   "runtime": "org.freedesktop.Platform",
-  "runtime-version": "unstable",
+  "runtime-version": "18.08",
   "sdk": "org.freedesktop.Sdk",
   "command": "viber",
   "separate-locales": false,

--- a/com.viber.Viber.json
+++ b/com.viber.Viber.json
@@ -3,7 +3,7 @@
   "base": "io.atom.electron.BaseApp",
   "base-version": "stable",
   "runtime": "org.freedesktop.Platform",
-  "runtime-version": "1.6",
+  "runtime-version": "unstable",
   "sdk": "org.freedesktop.Sdk",
   "command": "viber",
   "separate-locales": false,
@@ -34,7 +34,7 @@
         "install -Dm755 viber /app/bin/viber",
         "install -Dm644 com.viber.Viber.appdata.xml /app/share/appdata/com.viber.Viber.appdata.xml",
         "cp /usr/bin/ar /app/bin",
-        "cp /usr/lib/libbfd-*.so /app/lib"
+        "ARCH_TRIPLE=$(gcc --print-multiarch) && cp /usr/lib/${ARCH_TRIPLE}/libbfd-*.so /app/lib"
       ],
       "sources": [
         {


### PR DESCRIPTION
Freedesktop 18.07 works with multi-arch, so libraries are split out,
and libbfd has moved. This patch updates the copying of libbfd to
the new multi-arch system.

Obviously don't merge until freedesktop released as stable

Note: this is not backwards compatible with 1.6 as /usr/lib/{multiarch-triple}/libbfd.so doesn't exist in 1.6.