### PR TITLE
Updated hash and file size

### DIFF
--- a/com.viber.Viber.json
+++ b/com.viber.Viber.json
@@ -65,8 +65,8 @@
           "type": "extra-data",
           "filename": "viber.deb",
           "url": "https://download.cdn.viber.com/cdn/desktop/Linux/viber.deb",
-          "sha256": "bfc771fec15dacf4b1cbc6e64b7217c0ea14ce216a5e66f17022de255099d898",
-          "size": 94598834
+          "sha256": "1037a48d74caef33d123b166da2bfb1fe8fa67590b8669ecf25b314f41374267",
+          "size": 99693958
         },
         {
           "type": "script",


### PR DESCRIPTION
Was trying to install viber today and got
```
Error: Wrong size for extra data https://download.cdn.viber.com/cdn/desktop/Linux/viber.deb
error: Failed to install com.viber.Viber: Wrong size for extra data https://download.cdn.viber.com/cdn/desktop/Linux/viber.deb
```

There should be a way to ignore the hash, or better yet, automate the updating of the filesize and hash, if those are the values changed most often.