### PR TITLE
workaround: Fix Viber's tray icons

### DIFF
--- a/com.viber.Viber.json
+++ b/com.viber.Viber.json
@@ -19,10 +19,10 @@
         "--filesystem=xdg-videos",
         "--filesystem=xdg-documents",
         "--filesystem=xdg-download",
+        "--own-name=org.kde.*",
         "--device=all",
         "--talk-name=org.freedesktop.Notifications",
-        "--env=XDG_CURRENT_DESKTOP=Unity",
-        "--talk-name=org.kde.StatusNotifierWatcher"
+        "--env=XDG_CURRENT_DESKTOP=Unity"
     ],
     "modules": [
         {


### PR DESCRIPTION
This has been a long running issue #4 and it's been bothering me as well.

While this "fix" does introduce holes in the sandbox, namely the entire ```org.kde.*``` namespace being exposed, I think it's worth to merge it simply due to the issues that not having an tray icon would cause. (And the amount of frustration that brings)

1) Not being able to quit Viber is ONE BIG issue.
2) Having the ability to be aware that Viber's running on the system regardless whether the application window is open or not is pretty neat.
3) Keeping track of background tasks via the tray icons is cool as well.

So what's the rationale, why does Viber need an access to an entire session bus?

Basically since Viber DOES NOT use the ```org.kde.StatusNotifierItem``` bus, it instead opts to create it's own under the name ```org.kde.StatusNotifierItem-$randomNumber-$anotherRandomNumber```.

This has two problems:

1) Letting Viber talk to a bus won't work as it's **initiating** instead of using one. Hence the need for ```own-name```.

2) Flatpak doesn't allow string regexes. It does allow sub-package regexes, but not actual string regexes, because if that were the case I could do ```org.kde.StatusNotifierItem-*``` instead.

Hopefully this gets merged so that people using Viber don't have to scour yet another GitHub issue page and hopefully make Linux less tedious for them to use.

Cheers,
nikp123

EDIT: Formatting for GItHub's sake