### PR TITLE
Update to 21.08 runtimes

### DIFF
--- a/com.viber.Viber.json
+++ b/com.viber.Viber.json
@@ -1,9 +1,9 @@
 {
     "app-id": "com.viber.Viber",
-    "base": "io.atom.electron.BaseApp",
-    "base-version": "20.08",
+    "base": "org.electronjs.Electron2.BaseApp",
+    "base-version": "21.08",
     "runtime": "org.freedesktop.Platform",
-    "runtime-version": "20.08",
+    "runtime-version": "21.08",
     "sdk": "org.freedesktop.Sdk",
     "command": "viber",
     "separate-locales": false,


### PR DESCRIPTION
Runtime io.atom.electron.BaseApp is dead and even Atom switched to
org.electronjs.Electron2.BaseApp
(https://github.com/flathub/io.atom.Atom/blob/master/io.atom.Atom.json )
do so for Viber too it can use the 21.08 version.