### PR TITLE
Fix Viber failing to start after automated update

### DIFF
--- a/com.viber.Viber.appdata.xml
+++ b/com.viber.Viber.appdata.xml
@@ -21,7 +21,7 @@
     <category>P2P</category>
   </categories>
   <releases>
-    <release date="2021-09-28" version="16.1.0.37">
+    <release date="2022-08-12" version="18.2.0.2">
       <description>
         <ul>
           <li>Get Viber for Desktop to chat from the comfort of your computer.</li>

--- a/com.viber.Viber.json
+++ b/com.viber.Viber.json
@@ -2,9 +2,9 @@
     "app-id": "com.viber.Viber",
     "base": "org.electronjs.Electron2.BaseApp",
     "base-version": "21.08",
-    "runtime": "org.freedesktop.Platform",
-    "runtime-version": "21.08",
-    "sdk": "org.freedesktop.Sdk",
+    "runtime": "org.gnome.Platform",
+    "runtime-version": "42",
+    "sdk": "org.gnome.Sdk",
     "command": "viber",
     "separate-locales": false,
     "finish-args": [
@@ -72,6 +72,22 @@
                     "path": "com.viber.Viber.appdata.xml"
                 }
             ]
+        },
+        {
+          "name": "libsnappy",
+          "buildsystem": "cmake",
+          "config-opts":[
+ 				"-DSNAPPY_BUILD_TESTS=OFF",
+ 				"-DSNAPPY_BUILD_BENCHMARKS=OFF",
+ 				"-DBUILD_SHARED_LIBS=ON"
+  		  ],
+          "sources": [
+            {
+              "type": "archive",
+              "url": "https://github.com/google/snappy/archive/refs/tags/1.1.8.tar.gz",
+              "sha256": "16b677f07832a612b0836178db7f374e414f94657c138e6993cbfc5dcc58651f"
+            }
+          ]
         }
     ]
 }


### PR DESCRIPTION
Add module to build libsnappy 1.1.8, latest version 1.1.9 doesn't build
correctly as shared library.
Also had to switch the runtime to Gnome 42 as with freedesktop Viber
fails to launch with `/app/extra/viber/Viber: error while loading shared
libraries: libgssapi_krb5.so.2: cannot open shared object file: No such
file or directory
`.
Fixes https://github.com/flathub/com.viber.Viber/issues/49