### PR TITLE
Remove org.freedesktop.Notifications bus access

### DIFF
--- a/com.viber.Viber.json
+++ b/com.viber.Viber.json
@@ -20,7 +20,6 @@
         "--filesystem=xdg-documents",
         "--filesystem=xdg-download",
         "--device=all",
-        "--talk-name=org.freedesktop.Notifications",
         "--env=XDG_CURRENT_DESKTOP=Unity",
         "--talk-name=org.kde.StatusNotifierWatcher"
     ],


### PR DESCRIPTION
The electron baseapp has libnotify 0.8 which uses the portal for notifications, so this is no longer required

See https://gitlab.gnome.org/GNOME/libnotify/-/blob/69aff6e5fa2842e00b409c348bd73188548828b3/NEWS#L25