### PR TITLE
Fix: Detect Viber calls as user activity

### DIFF
--- a/com.viber.Viber.json
+++ b/com.viber.Viber.json
@@ -21,6 +21,10 @@
         "--filesystem=xdg-download",
         "--device=all",
         "--env=XDG_CURRENT_DESKTOP=Unity",
+        "--talk-name=org.freedesktop.PowerManagement",
+        "--talk-name=org.freedesktop.ScreenSaver",
+        "--talk-name=org.gnome.SessionManager",
+        "--talk-name=org.gtk.Notifications",
         "--talk-name=org.kde.StatusNotifierWatcher"
     ],
     "modules": [


### PR DESCRIPTION
Viber calls were not being recognized as user activity, leading to the OS suspending during calls.

This fix was tested on Debian 12 with Gnome desktop.