### PR TITLE
Download krb5 sources from a not-broken server

### DIFF
--- a/com.viber.Viber.json
+++ b/com.viber.Viber.json
@@ -128,7 +128,7 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "http://web.mit.edu/kerberos/dist/krb5/1.20/krb5-1.20.1.tar.gz",
+                    "url": "https://kerberos.org/dist/krb5/1.20/krb5-1.20.1.tar.gz",
                     "sha256": "704aed49b19eb5a7178b34b2873620ec299db08752d6a8574f95d41879ab8851"
                 }
             ],


### PR DESCRIPTION
The previous mirror was broken and sends the wrong Content-Encoding.